### PR TITLE
switch to python:3.5-slim-stretch base image

### DIFF
--- a/daemon/Dockerfile
+++ b/daemon/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.5
+FROM python:3.5-slim-stretch
 
 # -------------------------------------------
 # Daemon APT Install
@@ -11,7 +11,16 @@ ARG REMOTE_INIT_PWD=C1i3ntRmSid3
 
 RUN sed --in-place 's!$! non-free!' /etc/apt/sources.list  # add non-free repositories from snmp-mibs-downloader
 
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash -
+ENV BUILD_DEPENDENCIES apt-utils \
+  libc-dev \
+  gcc \
+  gnupg2
+RUN apt-get update \
+  && apt-get install --yes --no-install-recommends \
+  $BUILD_DEPENDENCIES \
+  curl \
+  && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+  && rm --recursive --force /var/lib/apt/lists/*
 RUN apt-get update \
   && apt-get install --yes --no-install-recommends --no-install-suggests \
   autossh \
@@ -130,4 +139,5 @@ COPY ./test /test
 
 COPY config/ /etc/supervisor/conf.d
 COPY help-me.mk /
+RUN apt-get purge --yes --auto-remove $BUILD_DEPENDENCIES
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/prod.conf"]


### PR DESCRIPTION
**fixes:** #21

## :warning: :skull_and_crossbones: Critic

* Changement de l'image docker sur laquelle est construite notre image `coaxis_daemon` . 
* Le dockerfile a été modifié pour rajouter les paquets debian manquant pour faire l'install du projet. 
* l'image docker `coaxisopt_daemon` passe de ~`950Mo` à ~`610Mo` (taille non compressé)

---

### DoD Checks (Definition of Done)

* [x] code
* [x] tests automatisés
* [ ] PR merged
* [ ] build/release to dockerHub
* [ ] deploy in production
* [ ] doc dans issue ou release note
